### PR TITLE
Fallback on license field

### DIFF
--- a/pins/pins.py
+++ b/pins/pins.py
@@ -176,20 +176,15 @@ class LicenseHandler(tornado.web.RequestHandler):
             r.raise_for_status()
         except requests.exceptions.HTTPError:
             return "error"
-        j = json.loads(r.content)
-        license = j['info'].get('license')
+        info = json.loads(r.content)['info']
+        license = info.get('license')
         # Use the license unless someone blobbed the whole license text in
         # this field. In this case fallback on classifers.
         if license and '\n' not in license:
             return license
-        classifiers = j['info']['classifiers']
-        if len(classifiers) > 0:
-            for l in classifiers:
-                if l.startswith("License"):
-                    bits = l.split(" :: ")
-                    if len(bits) == 3:
-                        return bits[2]
-                    return bits[1]
+        for classifier in info['classifiers']:
+            if classifier.startswith("License"):
+                return classifier.split(" :: ")[-1]
         return "unknown"
 
     def get(self, package):

--- a/pins/pins.py
+++ b/pins/pins.py
@@ -177,6 +177,11 @@ class LicenseHandler(tornado.web.RequestHandler):
         except requests.exceptions.HTTPError:
             return "error"
         j = json.loads(r.content)
+        license = j['info'].get('license')
+        # Use the license unless someone blobbed the whole license text in
+        # this field. In this case fallback on classifers.
+        if license and '\n' not in license:
+            return license
         classifiers = j['info']['classifiers']
         if len(classifiers) > 0:
             for l in classifiers:
@@ -185,7 +190,7 @@ class LicenseHandler(tornado.web.RequestHandler):
                     if len(bits) == 3:
                         return bits[2]
                     return bits[1]
-        return j['info'].get('license') or "unknown"
+        return "unknown"
 
     def get(self, package):
         self.set_header("Content-Type", "image/png")

--- a/pins/pins.py
+++ b/pins/pins.py
@@ -185,7 +185,7 @@ class LicenseHandler(tornado.web.RequestHandler):
                     if len(bits) == 3:
                         return bits[2]
                     return bits[1]
-        return "unknown"
+        return j['info'].get('license') or "unknown"
 
     def get(self, package):
         self.set_header("Content-Type", "image/png")


### PR DESCRIPTION
On PyPI one can only use well-known licenses in the classifier fields. The
field 'license' is a usefull fallback to lookup the license name in case no
classifier is available.
