### PR TITLE
If a package has no license set, it'll show up as 'UNKNOWN' instead of a...

### DIFF
--- a/pins/pins.py
+++ b/pins/pins.py
@@ -211,7 +211,7 @@ class LicenseHandler(tornado.web.RequestHandler):
         license = info.get('license')
         # Use the license unless someone blobbed the whole license text in
         # this field. In this case fallback on classifers.
-        if license and '\n' not in license:
+        if license and '\n' not in license and license.upper() != 'UNKNOWN':
             return license
         for classifier in info['classifiers']:
             if classifier.startswith("License"):


### PR DESCRIPTION
... blank string. This makes sure we still look at the classifiers.
