### PR TITLE
Bug in some version badge - escape `-` in version.

### DIFF
--- a/pins/pins.py
+++ b/pins/pins.py
@@ -102,7 +102,7 @@ class VersionHandler(PypiHandler):
     shield_subject = 'version'
 
     def handle_package_data(self, data):
-        return self.write_shield(data['info']['version'])
+        return self.write_shield(data['info']['version'].replace('-', '--'))
 
 
 def has_package(data, package_type):


### PR DESCRIPTION
Version included `-`  has been wrong generated badge.
example for ac https://pypi.python.org/pypi/ac version 0.3-alpha:

[![Build Status](https://pypip.in/v/ac/badge.png?)]()
