### PR TITLE
Remove dashes from license field

### DIFF
--- a/shields/shields.py
+++ b/shields/shields.py
@@ -11,6 +11,11 @@ import os
 import re
 import time
 
+try:
+    from urllib import quote as urllib_quote
+except ImportError:     # python3
+    from urllib.parse import quote as urllib_quote
+
 from klein import Klein
 from redis import Redis
 import requests
@@ -36,6 +41,7 @@ def format_number(singular, number):
 
 def escape_shield_query(text):
     """Escape text to be inserted in a shield API request."""
+    text = urllib_quote(text, safe=' ')
     text = text.replace('_', '__')
     text = text.replace(' ', '_')
     text = text.replace('-', '--')

--- a/shields/shields.py
+++ b/shields/shields.py
@@ -203,6 +203,7 @@ class LicenseHandler(PypiHandler):
     def handle_package_data(self):
         license = self.get_license()
         license = license.replace(' ', '_')
+        license = license.replace('-', '--')
         colour = "blue" if license != "unknown" else "red"
         return self.write_shield(license, colour)
 

--- a/shields/shields.py
+++ b/shields/shields.py
@@ -34,6 +34,14 @@ def format_number(singular, number):
     return value.replace('.0', '')
 
 
+def escape_shield_query(text):
+    """Escape text to be inserted in a shield API request."""
+    text = text.replace('_', '__')
+    text = text.replace(' ', '_')
+    text = text.replace('-', '--')
+    return text
+
+
 intword_converters = (
     (3, lambda number: format_number('%(value).1fk', number)),
     (6, lambda number: format_number('%(value).1fM', number)),
@@ -202,8 +210,7 @@ class LicenseHandler(PypiHandler):
 
     def handle_package_data(self):
         license = self.get_license()
-        license = license.replace(' ', '_')
-        license = license.replace('-', '--')
+        license = escape_shield_query(license)
         colour = "blue" if license != "unknown" else "red"
         return self.write_shield(license, colour)
 


### PR DESCRIPTION
Hey, this contains a fix for a very small issue encountered when a license
text contains a dash. E.g. if the license is "non-free". At the moment,
this will generate the following shield:

![shield](http://img.shields.io/badge/license-non-free-blue.png)

After the patch:

![shield](http://img.shields.io/badge/license-non_free-blue.png)

The same issue probably exists for other fields as well.
