### PR TITLE
Fix response termination on empty chunks

### DIFF
--- a/shields/shields.py
+++ b/shields/shields.py
@@ -113,8 +113,6 @@ class PypiHandler(object):
         shield_response = requests.get(shield_url, stream=True)
         img = BytesIO()
         for chunk in shield_response.iter_content(1024):
-            if not chunk:
-                break
             img.write(chunk)
         if self.cacheable:
             with open(cache, 'w') as ifile:


### PR DESCRIPTION
Hey, I was setting up another instance of this on my own server and discovered then that `.svg` didn't work, since the first chunk sent from `http://img.shields.io` would be empty for some reason.

I didn't see any explanation for the empty chunk check and so just removed it. If there is a good reason, feel free to ignore this PR.
