### PR TITLE
docs: fix simple typo, implemenation -> implementation

### DIFF
--- a/docs/source/implementation.rst
+++ b/docs/source/implementation.rst
@@ -8,7 +8,7 @@ This shield displays which implementations of Python your project supports.
     :target: https://pypi.python.org/pypi/blackhole/
     :alt: Supported Python implementations
 
-If no implemenation classifiers are found, we assume CPython.
+If no implementation classifiers are found, we assume CPython.
 
 Image URL
 ~~~~~~~~~


### PR DESCRIPTION
There is a small typo in docs/source/implementation.rst.

Should read `implementation` rather than `implemenation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md